### PR TITLE
Changed 'arch' command to 'uname -m' in Linux example.

### DIFF
--- a/example/execute_gnulinux/makesyro_gnulinux.sh
+++ b/example/execute_gnulinux/makesyro_gnulinux.sh
@@ -13,7 +13,7 @@ SCRIPT_PATH="$(readlink -f $0)"
 SCRIPT_NAME="$(basename $SCRIPT_PATH)"
 SCRIPT_DIR="$(dirname $SCRIPT_PATH)"
 
-ARCH=$(arch)
+ARCH=$(uname -m)
 SYRO_CMD="$SCRIPT_DIR/syro_volcasample_example.$ARCH"
 SYRO_TARGET_FILE="syro_stream.wav"
 


### PR DESCRIPTION
The 'arch' command is not installed by default in some distributions, 'uname' is more prevalent.