### PR TITLE
SyroComp_CompBlock: Prevent stack buffer overflow

### DIFF
--- a/syro/korg_syro_comp.c
+++ b/syro/korg_syro_comp.c
@@ -394,7 +394,7 @@ static int SyroComp_CompBlock(uint8_t *map_buffer, uint8_t *dest, ReadSample *pr
 	/*----- wrtie bit-base ------*/
 	j = 0;
 	for (i=0; i<16; i++) {
-		if (pBitBase[j]==i) {
+		if (j < 4 && pBitBase[j]==i) {
 			BitHead[i] = j++;
 			SyroComp_WriteBit(&wp, (uint32_t)(i-1), 4);
 		} else {


### PR DESCRIPTION
Closes #18.

I found a stack buffer overflow in SyroComp_CompBlock that didn't seem to result in any bugs when I compiled code with GCC.. however I consistently ran into problems when compiling to WebAssembly with Emscripten.

In this code:

https://github.com/korginc/volcasample/blob/b0ed615f18c230a18b378d9ddc6a936971597e4e/syro/korg_syro_comp.c#L394-L403

We can see that once `j` has been incremented to 4, the index 4 of `BitBase` (which doesn't exist) will be checked for the remainder of the loop. If the out of bounds memory happens to match `i` by accident, then we will get a false positive and write incorrect data.

Adding the index guard in this pull request solves the problem and makes my tests pass (for both GCC and Emscripten).