### PR TITLE
Add function SyroVolcaSample_GetCurData()

### DIFF
--- a/syro/korg_syro_volcasample.c
+++ b/syro/korg_syro_volcasample.c
@@ -789,3 +789,17 @@ SyroStatus SyroVolcaSample_End(SyroHandle Handle)
 	return Status_Success;
 }
 
+/*======================================================================
+	Syro Get Current Data Index
+ ======================================================================*/
+uint32_t SyroVolcaSample_GetCurData(SyroHandle Handle)
+{
+	SyroManage *psm;
+
+	psm = (SyroManage *)Handle;
+	if (psm->Header != SYRO_MANAGE_HEADER) {
+		return Status_InvalidHandle;
+	}
+
+	return (uint32_t)psm->CurData;
+}

--- a/syro/korg_syro_volcasample.h
+++ b/syro/korg_syro_volcasample.h
@@ -71,6 +71,8 @@ SyroStatus SyroVolcaSample_GetSample(SyroHandle Handle, int16_t *pLeft, int16_t 
 
 SyroStatus SyroVolcaSample_End(SyroHandle Handle);
 
+uint32_t SyroVolcaSample_GetCurData(SyroHandle Handle);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This is useful for keeping track of timestamps where different samples are located in the syro buffer, so you can give more detailed progress feedback to users. You can call `SyroVolcaSample_GetCurData()` anytime between `SyroVolcaSample_Start()` and `SyroVolcaSample_End()` to get the index of the `SyroData` currently being applied to the syro buffer.